### PR TITLE
[Update]管理者側_商品詳細画面のレイアウト修正

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -19,7 +19,7 @@ class Admin::ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @tax = @item.price * 0.1 + @item.price
+    @tax = (@item.price * 1.1).to_i
   end
 
   def edit

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,42 +1,50 @@
-<h5 class='offset-md-2 mt-4'>商品詳細</h5>
+<h5 class='offset-md-3 mt-5'>商品詳細</h5>
+
 <div class="container">
   <div class="row">
-    <div class="mx-auto mt-5">
-      <div class="float-left pr-5">
+    <div class="mx-auto mt-5 d-flex">
+      <div class="col-5 mr-4">
         <%= attachment_image_tag @item, :image, size: '250x200', format: 'jpeg', fallback: "img/no_image.jpg" %>
       </div>
 
-      <div class="float-right">
-        <div class="field">
-          <%= label_tag :name, "商品名", class: "col-6" %>
-          <%= @item.name %>
-        </div>
-        <div class="field d-flex">
-          <%= label_tag :introduction, "商品説明", class: "col-6" %>
-          <div class="col-10">
-            <%= @item.introduction %>
-          </div>
-        </div>
-        <div class="field">
-          <%= label_tag :genre, "ジャンル", class: "col-6" %>
-          <%= @item.genre.name %>
-        </div>
-        <div class="field">
-          <%= label_tag :price, "税込価格", class: "col-6" %><br>
-          <%= label_tag :price, "(税抜価格)", class: "col-6" %>
-          <%= @tax.to_i %>
-          （<%= @item.price %>）円
-        </div>
-        <div class="field d-flex">
-          <%= label_tag :is_active, "販売ステータス", class: "col-6" %>
-          <div class="sale-status">
-            <%= @item.is_active == true ? "販売中" : "販売停止中" %>
-          </div>
-        </div>
-        <div class="actions">
-          <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-success px-4 mt-4 offset-md-4" %>
-        </div>
-      </div>
+      <table class="col-8">
+        <tr>
+          <td><%= label_tag :name, "商品名", class: "small" %></td>
+          <td class="pl-4"><%= @item.name %></td>
+        </tr>
+        <tr>
+          <td><%= label_tag :introduction, "商品説明", class: "small" %></td>
+          <td class="pl-4"><%= @item.introduction %></td>
+        </tr>
+        <tr>
+          <td><%= label_tag :genre, "ジャンル", class: "small" %></td>
+          <td class="pl-4"><%= @item.genre.name %></td>
+        </tr>
+        <tr>
+          <td>
+            <%= label_tag :price, "税込価格", class: "small" %><br>
+            <%= label_tag :price, "(税抜価格)", class: "small" %>
+          </td>
+          <td class="pl-4">
+            <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= label_tag :is_active, "販売ステータス", class: "small" %>
+          </td>
+          <% if @item.is_active == true %>
+            <td class="status-green pl-4">
+              <strong>販売中</strong>
+            </td>
+          <% else %>
+            <td class="status-gray pl-4">
+              <strong>販売停止中</strong>
+            </td>
+          <% end %>
+        </tr>
+      </table>
     </div>
   </div>
+      <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-success px-4 mt-4 offset-md-6" %>
 </div>


### PR DESCRIPTION
管理者側の商品詳細画面のレイアウト修正しました。
・販売ステータスを「販売中：緑文字」「販売停止中：グレー文字」になるようにしました。
・税込みの記述を少し変更しました。⇨４桁以上にはカンマを付ける仕様。

ご確認お願いいたします。