### PR TITLE
[Fix]顧客側_注文履歴一覧をログインユーザー指定へ修正

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
   def index
-    @orders = Order.all.where(customer_id: current_customer.id)
+    @orders = Order.where(customer_id: current_customer.id)
   end
 
   def new

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
   def index
-    @orders = Order.all
+    @orders = Order.all.where(customer_id: current_customer.id)
   end
 
   def new


### PR DESCRIPTION
てっさんに指摘いただいた内容を修正しました！
⇨顧客側の注文履歴一覧をログインしたユーザー分のみ表示させる。

ご確認お願いいたします。