### PR TITLE
[Fix]商品一覧ページを1ページ8件表示＆全ページの件数を表示

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,44 +1,44 @@
 class CartItemsController < ApplicationController
-  
+
   def index
     @cart_items = CartItem.where(customer_id: current_customer.id)
   end
-  
+
   def create
-    @cart_item = current_user.cart_items.build(cart_item_params)
-    @cart_items = current_user.cart_items.all
+    @cart_item = current_customer.cart_items.build(cart_item_params)
+    @cart_items = current_customer.cart_items.all
     @cart_items.each do |cart_item|
       if cart_item.item_id == @cart_item.item_id
         new_amount = @cart_item.amount + @cart_item.amount
         cart_item.update_attribute(:amount, new_amount)
         @cart_item.delete
-      end 
+      end
     end
     @cart_item.save
     redirect_to customer_cart_items_path
   end
-  
+
   def update
     @cart_item = CartItem.find(params[:id])
     @cart_item.update(cart_item_params)
     redirect_to request.referer
   end
-  
+
   def destroy
     @cart_item = CartItem.find(params[:id])
     @cart_item.destroy
     redirect_to request.referer
   end
-  
+
   def destroy_all
     current_customer.cart_items.destroy_all
     redirect_to request.referer
   end
-  
+
   private
-  
+
   def cart_item_params
     params.require(:cart_item).permit(:item_id, :amount)
   end
-  
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,9 +8,5 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     @cart_item = CartItem.new
   end
-  
-  def create
-    
-  end
-
+ 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.all.order(created_at: :asc)
-    @item_page = @items.page(params[:page]).per(2)
+    @item_page = @items.page(params[:page]).per(8)
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.order(created_at: :asc).page(params[:page]).per(4)
+    @items = Item.all.order(created_at: :asc)
+    @item_page = @items.page(params[:page]).per(8)
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.all.order(created_at: :asc)
-    @item_page = @items.page(params[:page]).per(8)
+    @item_page = @items.page(params[:page]).per(2)
   end
 
   def show

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,9 +6,11 @@
   <div class="row">
     <% @item_page.each do |item| %>
       <div class="flex-column col-3 col-sm-3">
+        <%= link_to item_path(item.id) do %>
         <div><%= attachment_image_tag item, :image, :fill, 250, 200, format: 'jpeg' %></div>
         <div><%= item.name %></div>
         <div>¥<%= item.price.to_s(:delimited, delimiter: ',') %></div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,7 +4,7 @@
     <h4>全<%= @items.count %>件</h4>
   </div>
   <div class="row">
-    <% @items.each do |item| %>
+    <% @item_page.each do |item| %>
       <div class="flex-column col-3 col-sm-3">
         <div><%= attachment_image_tag item, :image, :fill, 250, 200, format: 'jpeg' %></div>
         <div><%= item.name %></div>
@@ -15,5 +15,5 @@
 </div>
 
 <div class="col-md-2 mt-4 col-md-offset-5 mx-auto">
-  <div class="mx-auto"><%= paginate @items %></div>
+  <div class="mx-auto"><%= paginate @item_page %></div>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,7 +6,7 @@
   <div class="row">
     <% @item_page.each do |item| %>
       <div class="flex-column col-3 col-sm-3">
-        <%= link_to item_path(item.id) do %>
+        <%= link_to  item_path(item.id) do %>
         <div><%= attachment_image_tag item, :image, :fill, 250, 200, format: 'jpeg' %></div>
         <div><%= item.name %></div>
         <div>¥<%= item.price.to_s(:delimited, delimiter: ',') %></div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -16,6 +16,6 @@
   </div>
 </div>
 
-<div class="col-md-2 mt-4 col-md-offset-5 mx-auto">
-  <div class="mx-auto"><%= paginate @item_page %></div>
+<div>
+  <%= paginate @item_page %>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -15,10 +15,13 @@
       </div>
       <%= render 'layouts/errors', obj: @item %>
       <div class="row">
-        <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer, @item), method: :post, local: true do |f| %>
-          <%= f.hidden_field :item_id, value: @item.id %>
-          <%= f.select :amount, options_for_select((1..10).to_a), {include_blank: "個数選択"}, class:"form-control" %>
-          <%= f.submit "カートに入れる", class:"btn btn-success" %>
+        
+        <% if customer_signed_in? %>
+          <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer, @item), local: true do |f| %>
+            <%= f.hidden_field :item_id, value: @item.id %>
+            <%= f.select :amount, options_for_select((1..10).to_a), {include_blank: "個数選択"}, class:"form-control" %>
+            <%= f.submit "カートに入れる", class:"btn btn-success" %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -15,7 +15,7 @@
       </div>
       <%= render 'layouts/errors', obj: @item %>
       <div class="row">
-        <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer), method: :post, local: true do |f| %>
+        <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer, @item), method: :post, local: true do |f| %>
           <%= f.hidden_field :item_id, value: @item.id %>
           <%= f.select :amount, options_for_select((1..10).to_a), {include_blank: "個数選択"}, class:"form-control" %>
           <%= f.submit "カートに入れる", class:"btn btn-success" %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link bg-secondary text-light rounded-circle' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,8 +1,3 @@
-<%# Non-link tag that stands for skipped pages...
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link bg-secondary text-light rounded-circle' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link bg-secondary text-light rounded-circle' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Next" page
-  - available local variables
-    url:           url to the next page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link bg-secondary text-light rounded-circle' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,12 +1,9 @@
-<%# Link showing page number
-  - available local variables
-    page:          a page object for "this" page
-    url:           url to this page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
-</span>
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link bg-secondary text-light rounded-circle' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link bg-secondary text-light rounded-circle' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,25 +1,17 @@
-<%# The container tag
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
-<%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.display_tag? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
-      <% end -%>
-    <% end -%>
-    <% unless current_page.out_of_range? %>
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination justify-content-center">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
       <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
-    <% end %>
+    </ul>
   </nav>
-<% end -%>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Previous" page
-  - available local variables
-    url:           url to the previous page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link bg-secondary text-light rounded-circle' %>
+</li>


### PR DESCRIPTION
商品一覧ページを1ページ8件表示(横並び2列)
全ページの合計商品件数を表示

上記2点を修正致しました。
ご確認の程、よろしくお願いいたします。