### PR TITLE
[Update]顧客側_注文情報入力画面のレイアウト修正、カート内商品の有無のif文追記

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,4 +69,3 @@
  #alert {
   color: red;
  }
-

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -1,98 +1,97 @@
 <h5 class='offset-md-2'>注文情報確認</h5>
 
 <%= form_with model: @order, local:true do |f| %>
-  <div class="container">
-    <div class="row">
-      <div class="col-md-8">
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th class="col-3"><%= f.label :item_id, "商品名" %></th>
-              <th class="col-3"><%= f.label :price, "単価(税込)" %></th>
-              <th class="col-3"><%= f.label :amount, "数量" %></th>
-              <th class="col-3">小計</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @sub_total = 0 %>
-            <% @cart_items.each do |cart_item| %>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-8">
+          <table class="table table-bordered">
+            <thead>
               <tr>
+                <th class="col-3"><%= f.label :item_id, "商品名" %></th>
+                <th class="col-3"><%= f.label :price, "単価(税込)" %></th>
+                <th class="col-3"><%= f.label :amount, "数量" %></th>
+                <th class="col-3">小計</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @sub_total = 0 %>
+              <% @cart_items.each do |cart_item| %>
+                <tr>
+                  <td>
+                    <%= attachment_image_tag cart_item.item, :image, size: '60x50', format: 'jpeg' %>
+                    <%= cart_item.item.name %>
+                  </td>
+                  <td>
+                    <%= (cart_item.item.price * 1.1).to_i %>
+                  </td>
+                  <td>
+                    <%= cart_item.amount %>
+                  </td>
+                  <td>
+                    <%= ((cart_item.item.price * 1.1) * cart_item.amount).to_i %>
+                    <% @sub_total += ((cart_item.item.price * 1.1) * cart_item.amount).to_i %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="col-md-4">
+          <table class="table table-bordered">
+            <tbody>
+              <tr>
+                <td><%= f.label :shipping_fee, "送料" %></td>
                 <td>
-                  <%= attachment_image_tag cart_item.item, :image, size: '60x50', format: 'jpeg' %>
-                  <%= cart_item.item.name %>
-                </td>
-                <td>
-                  <%= (cart_item.item.price * 1.1).to_i %>
-                </td>
-                <td>
-                  <%= cart_item.amount %>
-                </td>
-                <td>
-                  <%= ((cart_item.item.price * 1.1) * cart_item.amount).to_i %>
-                  <% @sub_total += ((cart_item.item.price * 1.1) * cart_item.amount).to_i %>
+                  <span>800</span>
+                  <%= f.hidden_field :shipping_fee, value: 800 %>
                 </td>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="col-md-4">
-        <table class="table table-bordered">
-          <tbody>
-            <tr>
-              <td><%= f.label :shipping_fee, "送料" %></td>
-              <td>
-                <span>800</span>
-                <%= f.hidden_field :shipping_fee, value: 800 %>
-              </td>
-            </tr>
-            <tr>
-              <td>商品合計</td>
-              <td>
-                <%= @sub_total.to_i %>
-              </td>
-            </tr>
-            <tr>
-              <td><%= f.label :payment_amount, "請求金額" %></td>
-              <td>
-                <%= @total = (@sub_total + 800).to_i %>
-                <%= f.hidden_field :payment_amount, value: @total %>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              <tr>
+                <td>商品合計</td>
+                <td>
+                  <%= @sub_total.to_i %>
+                </td>
+              </tr>
+              <tr>
+                <td><%= f.label :payment_amount, "請求金額" %></td>
+                <td>
+                  <%= @total = (@sub_total + 800).to_i %>
+                  <%= f.hidden_field :payment_amount, value: @total %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="offset-2">
-      <strong>支払方法</strong>
+    <div class="row">
+      <div class="offset-2">
+        <strong>支払方法</strong>
+      </div>
+      <div class="col-5">
+        <% if @order.payment_method == "クレジットカード" %>
+          <%= f.label :payment_method, "クレジットカード" %>
+          <%= f.hidden_field :payment_method, value: "クレジットカード" %>
+        <% else %>
+          <%= f.label :payment_method, "銀行振込" %>
+          <%= f.hidden_field :payment_method, value: "銀行振込" %>
+        <% end %>
+      </div>
     </div>
-    <div class="col-5">
-      <% if @order.payment_method == "クレジットカード" %>
-        <%= f.label :payment_method, "クレジットカード" %>
-        <%= f.hidden_field :payment_method, value: "クレジットカード" %>
-      <% else %>
-        <%= f.label :payment_method, "銀行振込" %>
-        <%= f.hidden_field :payment_method, value: "銀行振込" %>
-      <% end %>
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="offset-2">
-      <strong>お届け先</strong>
+    <div class="row">
+      <div class="offset-2">
+        <strong>お届け先</strong>
+      </div>
+      <div class="col-5">
+        <%= @order.postal_code %><%= @order.address %><br>
+        <%= @order.name %>
+        <%= f.hidden_field :postal_code %>
+        <%= f.hidden_field :address %>
+        <%= f.hidden_field :name %>
+      </div>
     </div>
-    <div class="col-5">
-      <%= @order.postal_code %><%= @order.address %><br>
-      <%= @order.name %>
-      <%= f.hidden_field :postal_code %>
-      <%= f.hidden_field :address %>
-      <%= f.hidden_field :name %>
-    </div>
-  </div>
-
-  <%= f.submit "注文を確定する", class: "btn btn-success px-4 mt-4 offset-md-5" %>
+    <%= f.submit "注文を確定する", class: "btn btn-success px-4 mt-4 offset-md-5" %>
 <% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,53 +1,64 @@
 <h5 class='offset-md-2 mt-4'>注文情報入力</h5>
-
 <div class="container">
   <div class="row mt-4">
-    <h5 class="offset-2"><strong>支払方法</strong></h5>
-    <%= form_with model: @order, url: orders_confirm_path, method: :post, local: true do |f| %>
-      <div class="form-group col-6">
-        <div class="radio-inline">
-          <%= f.radio_button :payment_method, "クレジットカード", checked: true %>
-          <%= f.label :payment_method, "クレジットカード" %>
-        </div>
-        <div class="radio-inline">
-          <%= f.radio_button :payment_method, "銀行振込" %>
-          <%= f.label :payment_method, "銀行振込" %>
-        </div>
+    <% if @cart_item == nil %>
+      <div class="mx-auto">
+        <h2>カートに商品が入っていません。</h2>
+        <%= link_to "商品一覧ページへ", items_path %>
       </div>
-
-      <h5><strong>お届け先</strong></h5>
-        <div class="form-group d-flex">
-          <%= f.radio_button :address_option, 0, checked: true %>
-          <%= f.label :address, "ご自身の住所", class: 'col-md-7 col-sm-8' %>
-          <div class="col-md-10 col-sm-11">
-          <%= @customer.postal_code %><%= @customer.address %><br>
-          <%= @customer.full_name %>
+    <% else %>
+    <div class="ml-5">
+      <%= form_with model: @order, url: orders_confirm_path, method: :post, local: true do |f| %>
+      <h5><strong>支払方法</strong></h5>
+        <div class="form-group">
+          <div class="radio-inline offset-md-1">
+            <%= f.radio_button :payment_method, "クレジットカード", checked: true %>
+            <%= f.label :payment_method, "クレジットカード" %>
+          </div>
+          <div class="radio-inline offset-md-1">
+            <%= f.radio_button :payment_method, "銀行振込" %>
+            <%= f.label :payment_method, "銀行振込" %>
           </div>
         </div>
 
-        <div class="form-group d-flex">
-          <%= f.radio_button :address_option, 1 %>
-          <%= f.label :address_id, "登録済住所から選択", class: 'col-md-7 col-sm-8' %>
-          <%= f.collection_select :address_id, Address.where(customer_id: current_customer.id), :id, :full_address, { include_blank: '選択してください'} %>
-        </div>
+        <h5><strong>お届け先</strong></h5>
+        <div class="offset-md-1">
+            <div class="form-group">
+              <%= f.radio_button :address_option, 0, checked: true %>
+              <%= f.label :address, "ご自身の住所", class: 'col-md-7 col-sm-8' %>
+              <div class="col-md-10 col-sm-11">
+              <%= @customer.postal_code %><%= @customer.address %><br>
+              <%= @customer.full_name %>
+              </div>
+            </div>
 
-        <%= f.radio_button :address_option, 2 %>
-        <%= f.label :address, "新しいお届け先", class: 'col-md-7 col-sm-8' %>
-        <div class='form-group d-flex'>
-          <%= f.label :postal_code, '郵便番号(ハイフンなし)', class: 'col-md-7 col-sm-8' %>
-          <%= f.text_field :postal_code, placeholder: '0000000', class: 'form-control col-md-3 col-sm-8' %>
+          <div class="form-group">
+            <%= f.radio_button :address_option, 1 %>
+            <%= f.label :address_id, "登録済住所から選択", class: 'col-md-7 col-sm-8' %>
+            <div class="col-md-10 col-sm-11">
+            <%= f.collection_select :address_id, Address.where(customer_id: current_customer.id), :id, :full_address, { include_blank: '選択してください'} %>
+            </div>
+          </div>
+
+          <%= f.radio_button :address_option, 2 %>
+          <%= f.label :address, "新しいお届け先", class: 'col-md-4 col-sm-5' %>
+          <div class='form-group d-flex'>
+            <%= f.label :postal_code, '郵便番号(ハイフンなし)', class: 'col-md-5 col-sm-6' %>
+            <%= f.text_field :postal_code, placeholder: '0000000', size: "20x10" %>
+          </div>
+          <div class='form-group d-flex'>
+            <%= f.label :address, '住所', class: 'col-md-5 col-sm-6'  %>
+            <%= f.text_field :address, placeholder: '東京都渋⾕区代々⽊神園町0-0', size: 60 %>
+          </div>
+          <div class='form-group d-flex'>
+            <%= f.label :name, '宛名', class: 'ccol-md-4 col-sm-5' %>
+            <%= f.text_field :name, placeholder: '令和道⼦', size:20 %>
+          </div>
+          <%= f.submit '確認画面へ進む', class: 'btn btn-sm btn-primary px-4 offset-md-4' %>
         </div>
-        <div class='form-group d-flex'>
-          <%= f.label :address, '住所', class: 'col-md-7 col-sm-8'  %>
-          <%= f.text_field :address, placeholder: '東京都渋⾕区代々⽊神園町0-0', class: 'form-control col-md-6 col-sm-8' %>
-        </div>
-        <div class='form-group d-flex'>
-          <%= f.label :name, '宛名', class: 'col-md-7 col-sm-8' %>
-          <%= f.text_field :name, placeholder: '令和道⼦', class: 'form-control col-md-3 col-sm-8' %>
-        </div>
-        <%= f.submit '確認画面へ進む', class: 'btn btn-sm btn-primary px-4 offset-md-3' %>
+      <% end %>
+    </div>
     <% end %>
   </div>
 </div>
-
 


### PR DESCRIPTION
顧客側の注文情報入力画面を修正しました！
・注文情報入力画面のレイアウト修正
⇨登録済住所をプルダウンで選択するフォームだけサイズ変更できませんでした…
何かよい方法があれば教えていただけますと幸いです。

・カート内の商品有無に関するif文の追記
⇨カートの中身がない場合は、注文情報入力できないようにしました。

※orders_confirm.htm.erblについて、すごい修正しているように見えますが、修正不要と判断したため、
結果、修正していない状態ですので、確認不要です。