### PR TITLE
[Update]カートが空の場合、商品一覧画面へ遷移する

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,6 +6,10 @@ class OrdersController < ApplicationController
   def new
     @order = Order.new
     @customer = current_customer
+    @cart = @customer.cart_items
+    if @cart.empty?
+        redirect_to items_path, alert: "カートに商品が入っていません。"
+    end
   end
 
   def confirm

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,12 +1,6 @@
 <h5 class='offset-md-2 mt-4'>注文情報入力</h5>
 <div class="container">
   <div class="row mt-4">
-    <% if @cart_item == nil %>
-      <div class="mx-auto">
-        <h2>カートに商品が入っていません。</h2>
-        <%= link_to "商品一覧ページへ", items_path %>
-      </div>
-    <% else %>
     <div class="ml-5">
       <%= form_with model: @order, url: orders_confirm_path, method: :post, local: true do |f| %>
       <h5><strong>支払方法</strong></h5>
@@ -58,7 +52,6 @@
         </div>
       <% end %>
     </div>
-    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
developにて検証したところ、ビューでの記述では上手くできなかったので、以下に修正しました。
＜カートが空の状態＞
・カート画面上で、情報入力ボタンを押下すると、商品一覧画面へ遷移する
・商品一覧画面へ遷移した際、画面左上に「カートに商品が入っていません」の赤字メッセージが表示される

お手数ですが、ご確認お願いいたします。
他に案がございましたら、連絡いただけますと幸いです…！