### PR TITLE
[Update]顧客側_商品詳細画面に販売停止中の表示

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,20 +10,28 @@
       <div class="mt-3">
         <%= @item.introduction %>
       </div>
-      <div class="d-flex mt-4">
-        <h5><strong>¥ <%= @item.add_tax_price.to_s(:delimited) %></strong></h5> <span>(税込)</span>
-      </div>
 
-      <div><%= render 'layouts/errors', obj: @cart_item %></div>
-        <% if customer_signed_in? %>
-          <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer, @item), local: true do |f| %>
-            <%= f.hidden_field :item_id, value: @item.id %>
-          <div class="row my-4">
-            <div class="mr-5 ml-3"><%= f.select :amount, options_for_select((1..50).to_a), {selected: 1}, class:"form-control btn-sm" %></div>
-            <div><%= f.submit "カートに入れる", class:"btn btn-red" %></div>
-          </div>
+      <% if @item.is_active == true %>
+        <div class="d-flex mt-4">
+          <h5><strong>¥ <%= @item.add_tax_price.to_s(:delimited) %></strong></h5> <span>(税込)</span>
+        </div>
+
+        <div><%= render 'layouts/errors', obj: @cart_item %></div>
+          <% if customer_signed_in? %>
+            <%= form_with model: @cart_item, url: customer_cart_items_path(current_customer, @item), local: true do |f| %>
+              <%= f.hidden_field :item_id, value: @item.id %>
+            <div class="row my-4">
+              <div class="mr-5 ml-3"><%= f.select :amount, options_for_select((1..50).to_a), {selected: 1}, class: "form-control btn-sm" %></div>
+              <div><%= f.submit "カートに入れる", class: "btn btn-red" %></div>
+            </div>
+            <% end %>
           <% end %>
-        <% end %>
-      </div>
+        </div>
+
+      <% else %>
+        <div class="row">
+          <span class="text-danger ml-4 mt-4"><strong>販売停止中</strong></span>
+        </div>
+      <% end %>
   </div>
 </div>


### PR DESCRIPTION
顧客側の商品詳細画面について、以下の修正を行いました。
・商品が販売停止中の場合
⇨価格、カート追加ボタンを非表示。「販売停止中」の赤文字を表示させる。

ご確認お願いいたします！