### PR TITLE
[Update]管理者側_検索結果テーブルの背景、商品詳細のレイアウト修正

### DIFF
--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,50 +1,47 @@
 <div class="container">
+  <h2 class='page_title mt-4'>商品詳細</h2>
   <div class="row col-md-10 mx-auto mt-5">
-    <h2 class='page_title mt-4'>商品詳細</h2>
-    <div class="row">
-      <div class="col-md-5">
-        <%= attachment_image_tag @item, :image, size: '380x280', format: 'jpeg', fallback: "img/no_image.jpg" %>
-      </div>
-
-      <div class="col-md-7">
-        <table>
-          <tr>
-            <td class="col-4"><%= label_tag :name, "商品名", class: "small" %></td>
-            <td><%= @item.name %></td>
-          </tr>
-          <tr>
-            <td class="col-4"><%= label_tag :introduction, "商品説明", class: "small" %></td>
-            <td><%= @item.introduction %></td>
-          </tr>
-          <tr>
-            <td class="col-4"><%= label_tag :genre, "ジャンル", class: "small" %></td>
-            <td><%= @item.genre.name %></td>
-          </tr>
-          <tr>
-            <td class="col-4">
-              <%= label_tag :price, "税込価格(税抜価格)", class: "small" %><br>
-            </td>
-            <td>
-              <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
-            </td>
-          </tr>
-          <tr>
-            <td class="col-4">
-              <%= label_tag :is_active, "販売ステータス", class: "small" %>
-            </td>
-            <% if @item.is_active == true %>
-              <td class="text-success">
-                <strong>販売中</strong>
-              </td>
-            <% else %>
-              <td class="text-muted">
-                <strong>販売停止中</strong>
-              </td>
-            <% end %>
-          </tr>
-        </table>
-      </div>
+    <div class="col-4">
+      <%= attachment_image_tag @item, :image, size: '350x250', format: 'jpeg', fallback: "img/no_image.jpg" %>
     </div>
-      <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-red px-4 mt-4 offset-md-6" %>
+    <div class="offset-1 col-6">
+      <table>
+        <tr>
+          <td class="col-3"><%= label_tag :name, "商品名", class: "small" %></td>
+          <td class="col-5"><%= @item.name %></td>
+        </tr>
+        <tr>
+          <td class="col-3"><%= label_tag :introduction, "商品説明", class: "small" %></td>
+          <td class="col-5"><%= @item.introduction %></td>
+        </tr>
+        <tr>
+          <td class="col-3"><%= label_tag :genre, "ジャンル", class: "small" %></td>
+          <td class="col-5"><%= @item.genre.name %></td>
+        </tr>
+        <tr>
+          <td class="col-3">
+            <%= label_tag :price, "税込価格(税抜価格)", class: "small" %><br>
+          </td>
+          <td class="col-5">
+            <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
+          </td>
+        </tr>
+        <tr>
+          <td class="col-3">
+            <%= label_tag :is_active, "販売ステータス", class: "small" %>
+          </td>
+          <% if @item.is_active == true %>
+            <td class="text-success col-5">
+              <strong>販売中</strong>
+            </td>
+          <% else %>
+            <td class="text-muted col-5">
+              <strong>販売停止中</strong>
+            </td>
+          <% end %>
+        </tr>
+      </table>
+    </div>
   </div>
+      <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-red px-4 mt-4 offset-md-6" %>
 </div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -10,21 +10,21 @@
         <table>
           <tr>
             <td class="col-4"><%= label_tag :name, "商品名", class: "small" %></td>
-            <td class="pl-4"><%= @item.name %></td>
+            <td><%= @item.name %></td>
           </tr>
           <tr>
             <td class="col-4"><%= label_tag :introduction, "商品説明", class: "small" %></td>
-            <td class="pl-4"><%= @item.introduction %></td>
+            <td><%= @item.introduction %></td>
           </tr>
           <tr>
             <td class="col-4"><%= label_tag :genre, "ジャンル", class: "small" %></td>
-            <td class="pl-4"><%= @item.genre.name %></td>
+            <td><%= @item.genre.name %></td>
           </tr>
           <tr>
             <td class="col-4">
               <%= label_tag :price, "税込価格(税抜価格)", class: "small" %><br>
             </td>
-            <td class="pl-4">
+            <td>
               <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
             </td>
           </tr>
@@ -33,11 +33,11 @@
               <%= label_tag :is_active, "販売ステータス", class: "small" %>
             </td>
             <% if @item.is_active == true %>
-              <td class="text-success pl-4">
+              <td class="text-success">
                 <strong>販売中</strong>
               </td>
             <% else %>
-              <td class="text-muted pl-4">
+              <td class="text-muted">
                 <strong>販売停止中</strong>
               </td>
             <% end %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,49 +1,50 @@
 <div class="container">
-  <h2 class='offset-md-2 page_title mt-4'>商品詳細</h2>
-  <div class="row">
-    <div class="mx-auto mt-5 d-flex">
-      <div class="col-5 mr-4">
-        <%= attachment_image_tag @item, :image, size: '250x200', format: 'jpeg', fallback: "img/no_image.jpg" %>
+  <div class="row col-md-10 mx-auto mt-5">
+    <h2 class='page_title mt-4'>商品詳細</h2>
+    <div class="row">
+      <div class="col-md-5">
+        <%= attachment_image_tag @item, :image, size: '380x280', format: 'jpeg', fallback: "img/no_image.jpg" %>
       </div>
 
-      <table class="col-8">
-        <tr>
-          <td><%= label_tag :name, "商品名", class: "small" %></td>
-          <td class="pl-4"><%= @item.name %></td>
-        </tr>
-        <tr>
-          <td><%= label_tag :introduction, "商品説明", class: "small" %></td>
-          <td class="pl-4"><%= @item.introduction %></td>
-        </tr>
-        <tr>
-          <td><%= label_tag :genre, "ジャンル", class: "small" %></td>
-          <td class="pl-4"><%= @item.genre.name %></td>
-        </tr>
-        <tr>
-          <td>
-            <%= label_tag :price, "税込価格", class: "small" %><br>
-            <%= label_tag :price, "(税抜価格)", class: "small" %>
-          </td>
-          <td class="pl-4">
-            <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <%= label_tag :is_active, "販売ステータス", class: "small" %>
-          </td>
-          <% if @item.is_active == true %>
-            <td class="text-success pl-4">
-              <strong>販売中</strong>
+      <div class="col-md-7">
+        <table>
+          <tr>
+            <td class="col-4"><%= label_tag :name, "商品名", class: "small" %></td>
+            <td class="pl-4"><%= @item.name %></td>
+          </tr>
+          <tr>
+            <td class="col-4"><%= label_tag :introduction, "商品説明", class: "small" %></td>
+            <td class="pl-4"><%= @item.introduction %></td>
+          </tr>
+          <tr>
+            <td class="col-4"><%= label_tag :genre, "ジャンル", class: "small" %></td>
+            <td class="pl-4"><%= @item.genre.name %></td>
+          </tr>
+          <tr>
+            <td class="col-4">
+              <%= label_tag :price, "税込価格(税抜価格)", class: "small" %><br>
             </td>
-          <% else %>
-            <td class="text-muted pl-4">
-              <strong>販売停止中</strong>
+            <td class="pl-4">
+              <%= @tax.to_s(:delimited) %>（<%= (@item.price).to_s(:delimited) %>）円
             </td>
-          <% end %>
-        </tr>
-      </table>
+          </tr>
+          <tr>
+            <td class="col-4">
+              <%= label_tag :is_active, "販売ステータス", class: "small" %>
+            </td>
+            <% if @item.is_active == true %>
+              <td class="text-success pl-4">
+                <strong>販売中</strong>
+              </td>
+            <% else %>
+              <td class="text-muted pl-4">
+                <strong>販売停止中</strong>
+              </td>
+            <% end %>
+          </tr>
+        </table>
+      </div>
     </div>
-  </div>
       <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-red px-4 mt-4 offset-md-6" %>
+  </div>
 </div>

--- a/app/views/admin/search/search.html.erb
+++ b/app/views/admin/search/search.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <div class="row">
     <h2>検索ワード '<%= @value %>'</h2>
-    <table class="table">
+    <table class="table bg-white">
       <% if @model == "customer" %>
-        <thead>
+        <thead class="thead-light">
           <tr>
             <th>会員ID</th>
             <th>氏名</th>


### PR DESCRIPTION
以下、修正しました。
・管理者側の検索結果テーブルの背景色を白色に修正。
・管理者側の商品詳細画面のレイアウトを修正。
⇨（税抜価格）の表示を横並びにしました。
⇨画面と文字の重なりを修正しました。
　ティラミス、マカロン、パンケーキが私のPC画面上では上手く表示されませんでした…
　一度、皆様の画面上で確認いただけますと幸いです^^;